### PR TITLE
Prevent error on scss-mode call by requiring flymake.

### DIFF
--- a/scss-mode.el
+++ b/scss-mode.el
@@ -29,6 +29,7 @@
 
 (require 'derived)
 (require 'compile)
+(require 'flymake)
 
 (defgroup scss nil
   "Scss mode"


### PR DESCRIPTION
If we load a .scss file without requiring flymake, emacs errors with the following message.

File mode specification error: (void-variable flymake-allowed-file-name-masks)

(require 'flymake) needs to be added to prevent this error.
