### PR TITLE
Small fix for files with spaces in their path.

### DIFF
--- a/scss-mode.el
+++ b/scss-mode.el
@@ -68,8 +68,8 @@ HYPERLINK HIGHLIGHT)"
   "Compiles the current buffer, sass filename.scss filename.css"
   (interactive)
     (compile (concat scss-sass-command " " ;; " --no-cache " " --cache-location"
-          buffer-file-name " "
-          (first (split-string buffer-file-name ".scss")) ".css")))
+          "'" buffer-file-name "' '"
+          (first (split-string buffer-file-name ".scss")) ".css'")))
 
 ;;;###autoload
 (define-derived-mode scss-mode css-mode "SCSS"


### PR DESCRIPTION
Small fix for files with spaces in their path: added quotes around file name arguments to sass command.
