### PR TITLE
Changed variable matching regular expression

### DIFF
--- a/scss-mode.el
+++ b/scss-mode.el
@@ -56,7 +56,7 @@ HYPERLINK HIGHLIGHT)"
 
 (defconst scss-font-lock-keywords
   ;; Variables
-  '(("\$[a-z_-]+" . font-lock-constant-face)
+  '(("\$[a-z_-0-9]+" . font-lock-constant-face)
     ("//.*$" . font-lock-comment-face)))
 
 (defun scss-compile-maybe()


### PR DESCRIPTION
The variable face was matching parenthesis so it was picking up variables in mixins and functions. 

For example,

```
@mixin inset-shadow($horizontal, $vertical, $blur, $color){
```

   -moz-box-shadow:inset $horizontal $vertical $blur $color;
   -webkit-box-shadow:inset $horizontal $vertical $blur $color;
   box-shadow:inset $horizontal $vertical $blur $color;
}

was matching "$color){" as a variable and giving that whole string the variable face as defined by my color-theme. this might not be the best or most robust regex but i think it should get the job done.
