### PR TITLE
Fixed quotes in single-line (//) comments.

### DIFF
--- a/scss-mode.el
+++ b/scss-mode.el
@@ -62,8 +62,7 @@ HYPERLINK HIGHLIGHT)"
 
 (defconst scss-font-lock-keywords
   ;; Variables
-  '(("$[a-z_-][a-z-_0-9]*" . font-lock-constant-face)
-    ("//.*$" . font-lock-comment-face)))
+  '(("$[a-z_-][a-z-_0-9]*" . font-lock-constant-face)))
 
 (defun scss-compile-maybe()
   "Runs `scss-compile' on if `scss-compile-at-save' is t"
@@ -83,6 +82,10 @@ HYPERLINK HIGHLIGHT)"
 Special commands:
 \\{scss-mode-map}"
   (font-lock-add-keywords nil scss-font-lock-keywords)
+  ;; Add the single-line comment syntax ('//', ends with newline)
+  ;; as comment style 'b' (see "Syntax Flags" in elisp manual)
+  (modify-syntax-entry ?/ ". 124b" css-mode-syntax-table)
+  (modify-syntax-entry ?\n "> b" css-mode-syntax-table)
   (add-to-list 'compilation-error-regexp-alist scss-compile-error-regex)
   (add-hook 'after-save-hook 'scss-compile-maybe nil t))
 


### PR DESCRIPTION
I believe this is the right way to fix the issue; I haven't tested it extensively but it seems to work in the files I've tried.

Single-line ('//'-style) comments are now parsed as part of the syntax table
instead of using font-lock. References:

http://www.emacswiki.org/emacs/EmacsSyntaxTable
http://www.gnu.org/software/emacs/manual/html_node/elisp/Syntax-Flags.html
