### PR TITLE
Support A Custom Output Directory For Compiled Files. Avoid Compiling Partial Files By Using The --update Option.

### DIFF
--- a/scss-mode.el
+++ b/scss-mode.el
@@ -75,14 +75,13 @@ HYPERLINK HIGHLIGHT)"
       (scss-compile)))
 
 (defun scss-compile()
-  "Compiles the current buffer, sass filename.scss filename.css"
+  "Compiles the directory belonging to the current buffer, using the --update option"
   (interactive)
-  (compile (concat scss-sass-command " " (mapconcat 'identity scss-sass-options " ") " "
-                   "'" buffer-file-name "' '"
-                   (if scss-output-directory
-                       (when (string-match ".*/\\(.+\\)[.]scss$" buffer-file-name)
-                         (concat scss-output-directory "/" (match-string 1 buffer-file-name)))
-                     (first (split-string buffer-file-name "[.]scss$"))) ".css'")))
+  (compile (concat scss-sass-command " " (mapconcat 'identity scss-sass-options " ") " --update "
+                   (when (string-match ".*/" buffer-file-name)
+                     (concat "'" (match-string 0 buffer-file-name) "'"))
+                   (when scss-output-directory
+                     (concat ":'" scss-output-directory "'")))))
 
 ;;;###autoload
 (define-derived-mode scss-mode css-mode "SCSS"


### PR DESCRIPTION
With this feature you can have your CSS files in your website public folder and keep SCSS files inside your source. 

You can configure this and other custom variables using Emacs DirectoryVariables by adding a file named ".dir-locals.el" in your scss directory. My current configuration is something like this:

((scss-mode (scss-sass-options . ("--cache-location" "../../../tmp/.sass-cache" "--style" "compressed"))
    (scss-output-directory . "../../../resources/public/stylesheets")))

This way I can set every project differently according to my needs. A feature very needed for projects not having Sass support as a plugin.

I have added an additional commit that compiles using the --update option to the whole directory the file buffer is in. This way partial files don't get compiled when saved.

The process should result in the same way as before. I don't think there would be overhead by compiling the whole directory since Saas will only compile changed files.
