### PR TITLE
Require flymake-proc to avoid compilation errors in Emacs HEAD

### DIFF
--- a/scss-mode.el
+++ b/scss-mode.el
@@ -31,6 +31,7 @@
 (require 'derived)
 (require 'compile)
 (require 'flymake)
+(require 'flymake-proc nil 'noerror)
 
 (defgroup scss nil
   "Scss mode"


### PR DESCRIPTION
flymake-allowed-file-name-masks has been removed in Emacs HEAD, causing compatibility issues. 
This PR updates the code to ensure it works correctly with the latest Emacs version.

See also: https://github.com/haskell/haskell-mode/pull/1828